### PR TITLE
Add bundle version and exported packages.

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -4,3 +4,5 @@ Export-Package: javax.cache;\
 	javax.cache.spi;\
 	javax.cache.transaction;
 Bundle-SymbolicName: javax.cache
+Bundle-Version: ${project.version}
+

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.5</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/src/main/java/javax/cache/annotation/packageinfo
+++ b/src/main/java/javax/cache/annotation/packageinfo
@@ -1,0 +1,2 @@
+# Declares the OSGi version of the package
+version 1.0

--- a/src/main/java/javax/cache/event/packageinfo
+++ b/src/main/java/javax/cache/event/packageinfo
@@ -1,0 +1,2 @@
+# Declares the OSGi version of the package
+version 1.0

--- a/src/main/java/javax/cache/packageinfo
+++ b/src/main/java/javax/cache/packageinfo
@@ -1,0 +1,2 @@
+# Declares the OSGi version of the package
+version 1.0

--- a/src/main/java/javax/cache/spi/packageinfo
+++ b/src/main/java/javax/cache/spi/packageinfo
@@ -1,0 +1,2 @@
+# Declares the OSGi version of the package
+version 1.0

--- a/src/main/java/javax/cache/transaction/packageinfo
+++ b/src/main/java/javax/cache/transaction/packageinfo
@@ -1,0 +1,2 @@
+# Declares the OSGi version of the package
+version 1.0


### PR DESCRIPTION
Note that the package versions are at 1.0 as they should follow the OSGi
semantic versioning scheme. More information about that can be found
here: www.osgi.org/wiki/uploads/Links/SemanticVersioning.pdf
In short: if the interfaces don't change the packages stay at 1.0. Only
if the interfaces in a particular package will the package version be
affected.
Also updated the dependency on the maven bundle plugin to version 2.3.5
(latest).
