### PR TITLE
Make CachingProvider Closeable

### DIFF
--- a/src/main/java/javax/cache/spi/CachingProvider.java
+++ b/src/main/java/javax/cache/spi/CachingProvider.java
@@ -9,6 +9,7 @@ package javax.cache.spi;
 
 import javax.cache.CacheManager;
 import javax.cache.configuration.OptionalFeature;
+import java.io.Closeable;
 import java.net.URI;
 import java.util.Properties;
 
@@ -24,7 +25,7 @@ import java.util.Properties;
  *
  * @author Brian Oliver
  */
-public interface CachingProvider {
+public interface CachingProvider extends Closeable {
 
   /**
    * Requests a {@link CacheManager} configured according to the implementation


### PR DESCRIPTION
Cache and CacheManager have a `#close` method and extend `Closeable`.
CachingProvider has a `#close` method but does not extend `Closeable`
- make CachingProvider extend Closeable

Mailing list discussion:
https://groups.google.com/forum/#!topic/jsr107/Z0TbFJm-vkk

I did sign the Terracotta Contributor Argeement.
