### PR TITLE
fix typos in remove methods. for CacheException javadoc change "put" to ...

### DIFF
--- a/src/main/java/javax/cache/Cache.java
+++ b/src/main/java/javax/cache/Cache.java
@@ -300,7 +300,7 @@ public interface Cache<K, V> extends Iterable<Cache.Entry<K, V>>, Closeable {
    * @return returns false if there was no matching key
    * @throws NullPointerException  if key is null
    * @throws IllegalStateException if the cache is {@link #isClosed()}
-   * @throws CacheException        if there is a problem doing the put
+   * @throws CacheException        if there is a problem doing the remove
    * @throws ClassCastException    if the implementation supports and is
    *                               configured to perform runtime-type-checking,
    *                               and the key type is incompatible with that
@@ -329,7 +329,7 @@ public interface Cache<K, V> extends Iterable<Cache.Entry<K, V>>, Closeable {
    * @return returns false if there was no matching key
    * @throws NullPointerException  if key is null
    * @throws IllegalStateException if the cache is {@link #isClosed()}
-   * @throws CacheException        if there is a problem doing the put
+   * @throws CacheException        if there is a problem doing the remove
    * @throws ClassCastException    if the implementation supports and is
    *                               configured to perform runtime-type-checking,
    *                               and the key or value types are incompatible


### PR DESCRIPTION
fix javadoc typos in remove methods. For @throws CacheException, change cut and paste error of "put" to "remove"
