### PR TITLE
Fix Javadoc Warnings

### DIFF
--- a/src/main/java/javax/cache/annotation/package-info.java
+++ b/src/main/java/javax/cache/annotation/package-info.java
@@ -6,19 +6,26 @@
  */
 
 /**
- * The annotations in this package provide method interceptors for user supplied classes.
+ * The annotations in this package provide method interceptors for user supplied
+ * classes.
  *
- * In the case of a the {@link CacheResult} annotation, if the cache can satisfy the request a result is returned
- * by the method from cache, not from method execution. For the mutative annotations such as {@link CacheResult}
- * the annotation allows the cached value to be mutated so that it will be correct the next time {@link CacheResult} is used.
+ * In the case of a the {@link javax.cache.annotation.CacheResult} annotation,
+ * if the cache can satisfy the request a result is returned by the method from
+ * cache, not from method execution. For the mutative annotations such as
+ * {@link javax.cache.annotation.CacheResult} the annotation allows the cached
+ * value to be mutated so that it will be correct the next time
+ * {@link javax.cache.annotation.CacheResult} is used.
  * <p/>
- * Any operations against a cache via an annotation will have the same behaviour as if the {@link CacheResult} methods were used. So
- * if the same underlying cache is used for an annotation and a direct API call, the same data would be returned. Annotations
- * therefore provide an additional API for interacting with caches.
+ * Any operations against a cache via an annotation will have the same behaviour
+ * as if the {@link javax.cache.annotation.CacheResult} methods were used. So
+ * if the same underlying cache is used for an annotation and a direct API call,
+ * the same data would be returned. Annotations therefore provide an additional
+ * API for interacting with caches.
  * <p/>
- * In order to use these annotations, you'll need a library or framework which processes these annotations and intercepts calls
- * to your application objects to provide the caching behaviour. This would commonly be provided by a dependency injection framework
- * such as defined by CDI in Java EE.
+ * In order to use these annotations, you'll need a library or framework which
+ * processes these annotations and intercepts calls to your application objects
+ * to provide the caching behaviour. This would commonly be provided by a
+ * dependency injection framework such as defined by CDI in Java EE.
  *
  *  @author Eric Dalquist
  *  @author Greg Luck

--- a/src/main/java/javax/cache/configuration/package-info.java
+++ b/src/main/java/javax/cache/configuration/package-info.java
@@ -22,8 +22,9 @@
  *            new AccessedExpiryPolicy<String>(new Duration(TimeUnit.HOURS, 1))));
  * </code></pre>
  * <p/>
- * {@link OptionalFeature}, though not specific to cache configuration, allows
- * application to determine the optional features supported at runtime.
+ * {@link javax.cache.configuration.OptionalFeature}, though not specific to
+ * cache configuration, allows application to determine the optional features
+ * supported at runtime.
  *
  * @author Greg Luck
  * @since 1.0

--- a/src/main/java/javax/cache/integration/package-info.java
+++ b/src/main/java/javax/cache/integration/package-info.java
@@ -8,8 +8,8 @@
 /**
  * This package contains interfaces for integration.
  * <p/>
- * It contains the {@link CacheLoader} and
- * {@link CacheWriter} interfaces which
+ * It contains the {@link javax.cache.integration.CacheLoader} and
+ * {@link javax.cache.integration.CacheWriter} interfaces which
  * allow loading from and writing to other systems respectively.
  * <p/>
  * A cache with a registered loader can be configured as a read-through cache, so
@@ -19,8 +19,9 @@
  * system.
  * <p/>
  * In addition a common idiom is to use a loader to initially
- * populate or refresh a cache. For that purpose there is the {@link
- * Cache#loadAll(java.util.Set, boolean, CompletionListener)} method.
+ * populate or refresh a cache. For that purpose there is the
+ * {@link javax.cache.Cache#loadAll(java.util.Set, boolean, CompletionListener)}
+ * method.
  *
  * @author Greg Luck
  * @since 1.0

--- a/src/main/java/javax/cache/package-info.java
+++ b/src/main/java/javax/cache/package-info.java
@@ -9,13 +9,14 @@
  * <p/>
  * This package contains the API for JCache.
  * <p/>
- * The entry point is the {@link Caching} class. {@link CacheManager} holds and controls
- * a collection of {@link Cache}s.
+ * The entry point is the {@link javax.cache.Caching} class.
+ * {@link javax.cache.CacheManager} holds and controls a collection of
+ * {@link javax.cache.Cache}s.
  * <p/>
  * A cache is an association of key to value.
  * <p/>
  * Implementations may optionally enforce security restrictions. In case of a
- * violation, a {@link SecurityException} must be thrown.
+ * violation, a {@link java.lang.SecurityException} must be thrown.
  *
  * @author Greg Luck
  * @author Yannis Cosmadopoulos

--- a/src/main/java/javax/cache/processor/EntryProcessor.java
+++ b/src/main/java/javax/cache/processor/EntryProcessor.java
@@ -8,38 +8,40 @@ import javax.cache.integration.CacheWriter;
 
 /**
  * An invokable function that allows applications to perform compound
- * operations on a {@link Cache.Entry} atomically, according the defined
- * consistency of a {@link Cache}.
+ * operations on a {@link javax.cache.Cache.Entry} atomically, according the
+ * defined consistency of a {@link Cache}.
  * <p/>
- * Any {@link Cache.Entry} mutations will not take effect until after the
- * {@link EntryProcessor#process(MutableEntry, Object...)}
+ * Any {@link javax.cache.Cache.Entry} mutations will not take effect until
+ * after the {@link EntryProcessor#process(MutableEntry, Object...)}
  * method has completed execution.
  * <p/>
  * If an exception is thrown by an {@link EntryProcessor}, a Caching
  * Implementation must wrap any {@link Exception} thrown wrapped in an {@link
  * EntryProcessorException}. If this occurs no mutations will be made to the
- * {@link Cache.Entry}.
+ * {@link javax.cache.Cache.Entry}.
  * <p/>
  * Implementations may execute {@link EntryProcessor}s in situ, thus avoiding
  * locking, round-trips and expensive network transfers.
  * <p/>
  * <h3>Effect of {@link MutableEntry} operations</h3>
- * {@link Cache.Entry} access, via a call to {@link Cache.Entry#getValue()}, will
- * behave as if {@link Cache#get(Object)} was called for the key.  This includes
+ * {@link javax.cache.Cache.Entry} access, via a call to
+ * {@link javax.cache.Cache.Entry#getValue()}, will behave as if
+ * {@link Cache#get(Object)} was called for the key.  This includes
  * updating necessary statistics, consulting the configured {@link ExpiryPolicy}
  * and loading from a configured {@link javax.cache.integration.CacheLoader}.
  * <p/>
- * {@link Cache.Entry} mutation, via a call to
+ * {@link javax.cache.Cache.Entry} mutation, via a call to
  * {@link MutableEntry#setValue(Object)}, will behave as if {@link
  * Cache#put(Object, Object)} was called for the key.
  * This includes updating necessary statistics, consulting the configured {@link
  * ExpiryPolicy}, notifying {@link CacheEntryListener}s and writing to a
  * configured {@link CacheWriter}.
  * <p/>
- * {@link Cache.Entry} removal, via a call to {@link MutableEntry#remove()}, will
- * behave as if {@link Cache#remove(Object)} was called for the key. This includes
- * updating necessary statistics, notifying {@link CacheEntryListener}s and
- * causing a delete on a configured {@link CacheWriter}.
+ * {@link javax.cache.Cache.Entry} removal, via a call to
+ * {@link MutableEntry#remove()}, will behave as if {@link Cache#remove(Object)}
+ * was called for the key. This includes updating necessary statistics, notifying
+ * {@link CacheEntryListener}s and causing a delete on a configured
+ * {@link CacheWriter}.
  * <p/>
  * As implementations may choose to execute {@link EntryProcessor}s remotely,
  * {@link EntryProcessor}s, together with specified parameters and return

--- a/src/main/java/javax/cache/processor/MutableEntry.java
+++ b/src/main/java/javax/cache/processor/MutableEntry.java
@@ -3,7 +3,7 @@ package javax.cache.processor;
 import javax.cache.Cache;
 
 /**
- * A mutable representation of a {@link Cache.Entry}.
+ * A mutable representation of a {@link javax.cache.Cache.Entry}.
  *
  * @param <K> the type of key
  * @param <V> the type of value

--- a/src/main/java/javax/cache/processor/package-info.java
+++ b/src/main/java/javax/cache/processor/package-info.java
@@ -10,7 +10,7 @@
  * This package contains the API for Entry Processors.
  * <p/>
  * Implementations may optionally enforce security restrictions. In case of a
- * violation, a {@link SecurityException} must be thrown.
+ * violation, a {@link java.lang.SecurityException} must be thrown.
  *
  * @author Greg Luck
  * @since 1.0


### PR DESCRIPTION
This commit fixes all the Javadoc warnings I have when building
locally. These are all {@link } references that can not be resolved
and result in no hyperlink being generated in the resulting HTML.

The cause seem to be two different limitations in the Javadoc tool
- `package-info.html` apparently always needs fully qualified class
  names even if they are in the same package or in `java.lang`.
- Referencig nested types (`Cache.Entry`) in Javadoc does not work
  when only the outer type (`Cache.Entry`) is imported. You could
  import the nested type but when it is only referenced qualified in
  the code then the IDE is likely to generated an unused import
  warning.

I did sign the Terracotta Contributor Agreement.
