### PR TITLE
Fix < and > Javadoc Warnings

### DIFF
--- a/src/main/java/javax/cache/package-info.java
+++ b/src/main/java/javax/cache/package-info.java
@@ -152,14 +152,14 @@
  * CacheManager cacheManager = cachingProvider.getCacheManager();
  *
  * //configure the cache
- * MutableConfiguration<String, Integer> config =
- *    new MutableConfiguration<>()
+ * MutableConfiguration&lt;String, Integer&gt; config =
+ *    new MutableConfiguration&lt;&gt;()
  *    .setTypes(String.class, Integer.class)
  *    .setExpiryPolicyFactory(AccessedExpiryPolicy.factoryOf(ONE_HOUR))
  *    .setStatisticsEnabled(true);
  *
  * //create the cache
- * Cache<String, Integer> cache = cacheManager.createCache("simpleCache", config);
+ * Cache&lt;String, Integer&gt; cache = cacheManager.createCache("simpleCache", config);
  *
  * //cache operations
  * String key = "key";


### PR DESCRIPTION
There are a few more Javadoc warnings to the point where the project
will not build with the Java 8 Javadoc DocLint [1].

This change includes the following:

 * replace < and > with &amp;lt; and &amp;gt; in one place

I did sign the Terracotta Contributor Argreement.

 [1] http://openjdk.java.net/jeps/172