### PR TITLE
Get specific property while looking up CachingProvider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>javax.cache</groupId>
     <artifactId>cache-api</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JSR107 API and SPI</name>

--- a/src/main/java/javax/cache/Caching.java
+++ b/src/main/java/javax/cache/Caching.java
@@ -433,8 +433,8 @@ public final class Caching {
 
       if (providers == null) {
 
-        if (System.getProperties().containsKey(JAVAX_CACHE_CACHING_PROVIDER)) {
-          String className = System.getProperty(JAVAX_CACHE_CACHING_PROVIDER);
+        String className = System.getProperty(JAVAX_CACHE_CACHING_PROVIDER);
+        if (className != null) {
           providers = new LinkedHashMap<String, CachingProvider>();
           providers.put(className, loadCachingProvider(className, serviceClassLoader));
 


### PR DESCRIPTION
* Bumps version to next patch snapshot
* Fixes #398 by requiring only read access for specific property while looking up `CachingProvider` implementation