### PR TITLE
Fixes javadoc generation when using JDK >= 10 to build JCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ implementations.
 Building From Source
 --------------------
 
-Building uses Maven in all modules. Maven 3.3.9 - 3.5.0 have been tested.
+Building uses Maven in all modules. Maven 3.3.9 - 3.5.4 have been tested.
 
-JCache is compatible with Java 6 to Java 9. We have tested building from Java 8 and Java 9.
+JCache is compatible with Java 6 to Java 11. We have tested building from Java 8 and Java 11.
 
 See each module's README.md for build instructions.
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Upgrades maven-javadoc-plugin to 3.0.1 which includes a fix for
newer JDKs.

Fixes #404 