### PR TITLE
Fixes typo in Caching class javadoc

### DIFF
--- a/src/main/java/javax/cache/Caching.java
+++ b/src/main/java/javax/cache/Caching.java
@@ -56,7 +56,7 @@ import java.util.WeakHashMap;
  * <p>
  * Alternatively when the fully qualified class name of a
  * {@link CachingProvider} implementation is specified using the system property
- * <code>javax.cache.spi.cachingprovider</code>, that implementation will be used
+ * <code>javax.cache.spi.CachingProvider</code>, that implementation will be used
  * as the default {@link CachingProvider}.
  * <p>
  * All {@link CachingProvider}s that are automatically detected or explicitly


### PR DESCRIPTION
The system property name for specifying
the `CachingProvider` class name has incorrect
capitalization in the class' javadoc.

Fixes #410 