### PR TITLE
Fix SCM in pom.xml to point to correct repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,10 +256,9 @@
     </profiles>
 
     <scm>
-        <connection>scm:git:git@github.com:juven/git-demo.git</connection>
-        <developerConnection>scm:git:git@github.com:juven/git-demo.git
-        </developerConnection>
-        <url>git@github.com:juven/git-demo.git</url>
+        <connection>scm:git:https://github.com/jsr107/jsr107spec.git</connection>
+        <developerConnection>scm:git:git@github.com:jsr107/jsr107spec.git</developerConnection>
+        <url>https://github.com/jsr107/jsr107spec</url>
     </scm>
 
 


### PR DESCRIPTION
Fix URLs to point to hte correct upstream source code repository
and fix values to conform to http://maven.apache.org/pom.html#scm.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>