### PR TITLE
add copyright to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,19 @@
+<!--
+ Copyright 2011-2016 Terracotta, Inc.
+ Copyright 2011-2016 Oracle America Incorporated
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">


### PR DESCRIPTION
### Add copyright information to pom.xml.

For a customer project an OpenSource report has to be generated. Therefore a scanner was created to extract the copyright and licence information from our dependencies. This scanner can extract all informaton from pom.xml. Therefore it would be great to have the copyright in the pom.xml like other libraries do. 